### PR TITLE
Remove setuptools from install_requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 python_dateutil >= 2.5.3
-setuptools >= 21.0.0
 urllib3 >= 1.25.3, < 2.1.0
 pydantic >= 1.10.5
 aenum >= 3.1.11


### PR DESCRIPTION
It is only required at build time.