### PR TITLE
Remove aenum from install_requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.25.3, < 2.1.0
 pydantic >= 1.10.5
-aenum >= 3.1.11
 aiohttp >= 3.0.0


### PR DESCRIPTION
I can't find any mention of it in the code.